### PR TITLE
Handle offline permissions asynchronously

### DIFF
--- a/API/src/main/java/fr/maxlego08/zauctionhouse/api/configuration/records/ExpirationConfiguration.java
+++ b/API/src/main/java/fr/maxlego08/zauctionhouse/api/configuration/records/ExpirationConfiguration.java
@@ -10,6 +10,7 @@ import org.bukkit.entity.Player;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
 
 public record ExpirationConfiguration(long defaultExpiration, boolean enablePermission, Map<String, Long> expirations) {
 
@@ -44,16 +45,24 @@ public record ExpirationConfiguration(long defaultExpiration, boolean enablePerm
         return expiration;
     }
 
-    public long getExpiration(OfflinePermission offlinePermission, OfflinePlayer offlinePlayer) {
+    public CompletableFuture<Long> getExpiration(OfflinePermission offlinePermission, OfflinePlayer offlinePlayer) {
         long expiration = this.defaultExpiration;
         if (this.enablePermission) {
-            var results = offlinePermission.hasPermissions(offlinePlayer, this.expirations.keySet());
-            for (OfflinePermissionResult result : results) {
-                if (result.result()) {
-                    expiration = Math.max(expiration, this.expirations.get(result.permission()));
-                }
-            }
+            return offlinePermission.hasPermissions(offlinePlayer, this.expirations.keySet())
+                    .handle((results, throwable) -> {
+                        if (throwable != null || results == null) {
+                            return expiration;
+                        }
+
+                        long newExpiration = expiration;
+                        for (OfflinePermissionResult result : results) {
+                            if (result.result()) {
+                                newExpiration = Math.max(newExpiration, this.expirations.get(result.permission()));
+                            }
+                        }
+                        return newExpiration;
+                    });
         }
-        return expiration;
+        return CompletableFuture.completedFuture(expiration);
     }
 }

--- a/API/src/main/java/fr/maxlego08/zauctionhouse/api/hooks/permission/OfflinePermission.java
+++ b/API/src/main/java/fr/maxlego08/zauctionhouse/api/hooks/permission/OfflinePermission.java
@@ -4,9 +4,10 @@ import org.bukkit.OfflinePlayer;
 
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
 
 public interface OfflinePermission {
 
-    List<OfflinePermissionResult> hasPermissions(OfflinePlayer offlinePlayer, Set<String> permissions);
+    CompletableFuture<List<OfflinePermissionResult>> hasPermissions(OfflinePlayer offlinePlayer, Set<String> permissions);
 
 }

--- a/Hooks/LuckPerms/src/main/java/fr/maxlego08/zauctionhouse/hooks/permissions/LuckPermsOfflinePermission.java
+++ b/Hooks/LuckPerms/src/main/java/fr/maxlego08/zauctionhouse/hooks/permissions/LuckPermsOfflinePermission.java
@@ -9,6 +9,7 @@ import org.bukkit.OfflinePlayer;
 
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
 
 public class LuckPermsOfflinePermission implements OfflinePermission {
 
@@ -19,14 +20,15 @@ public class LuckPermsOfflinePermission implements OfflinePermission {
     }
 
     @Override
-    public List<OfflinePermissionResult> hasPermissions(OfflinePlayer offlinePlayer, Set<String> permissions) {
-        User user = this.luckPerms.getUserManager().loadUser(offlinePlayer.getUniqueId()).join();
-        if (user == null) {
-            return permissions.stream().map(permission -> new OfflinePermissionResult(permission, false)).toList();
-        }
+    public CompletableFuture<List<OfflinePermissionResult>> hasPermissions(OfflinePlayer offlinePlayer, Set<String> permissions) {
+        return this.luckPerms.getUserManager().loadUser(offlinePlayer.getUniqueId()).thenApply(user -> {
+            if (user == null) {
+                return permissions.stream().map(permission -> new OfflinePermissionResult(permission, false)).toList();
+            }
 
-        var permissionData = user.getCachedData().getPermissionData(this.luckPerms.getContextManager().getStaticQueryOptions());
+            var permissionData = user.getCachedData().getPermissionData(this.luckPerms.getContextManager().getStaticQueryOptions());
 
-        return permissions.stream().map(permission -> new OfflinePermissionResult(permission, permissionData.checkPermission(permission).asBoolean())).toList();
+            return permissions.stream().map(permission -> new OfflinePermissionResult(permission, permissionData.checkPermission(permission).asBoolean())).toList();
+        });
     }
 }

--- a/src/main/java/fr/maxlego08/zauctionhouse/hooks/permissions/EmptyOfflinePermission.java
+++ b/src/main/java/fr/maxlego08/zauctionhouse/hooks/permissions/EmptyOfflinePermission.java
@@ -6,11 +6,12 @@ import org.bukkit.OfflinePlayer;
 
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
 
 public class EmptyOfflinePermission implements OfflinePermission {
 
     @Override
-    public List<OfflinePermissionResult> hasPermissions(OfflinePlayer offlinePlayer, Set<String> permissions) {
-        return permissions.stream().map(permission -> new OfflinePermissionResult(permission, false)).toList();
+    public CompletableFuture<List<OfflinePermissionResult>> hasPermissions(OfflinePlayer offlinePlayer, Set<String> permissions) {
+        return CompletableFuture.completedFuture(permissions.stream().map(permission -> new OfflinePermissionResult(permission, false)).toList());
     }
 }

--- a/src/main/java/fr/maxlego08/zauctionhouse/services/ExpireService.java
+++ b/src/main/java/fr/maxlego08/zauctionhouse/services/ExpireService.java
@@ -10,6 +10,8 @@ import fr.maxlego08.zauctionhouse.api.item.StorageType;
 import fr.maxlego08.zauctionhouse.api.services.AuctionExpireService;
 
 import java.util.Date;
+import java.util.function.Consumer;
+import java.util.logging.Level;
 
 public class ExpireService implements AuctionExpireService {
 
@@ -43,15 +45,27 @@ public class ExpireService implements AuctionExpireService {
 
             item.setStatus(ItemStatus.REMOVED);
             
-            var expiration = offlineSeller.isOnline() ?
-                    configuration.getExpireExpiration().getExpiration(offlineSeller.getPlayer())
-                    : configuration.getExpireExpiration().getExpiration(this.plugin.getOfflinePermission(), offlineSeller);
+            Consumer<Long> applyExpiration = expiration -> this.plugin.getScheduler().runNextTick(w -> {
+                long expiredAt = expiration > 0 ? System.currentTimeMillis() + (expiration * 1000) : 0;
+                item.setExpiredAt(new Date(expiredAt));
 
-            long expiredAt = expiration > 0 ? System.currentTimeMillis() + (expiration * 1000) : 0;
-            item.setExpiredAt(new Date(expiredAt));
+                this.auctionManager.addItem(StorageType.EXPIRED, item);
+                storageManager.updateItem(item, StorageType.EXPIRED);
+            });
 
-            this.auctionManager.addItem(StorageType.EXPIRED, item);
-            storageManager.updateItem(item, StorageType.EXPIRED);
+            if (offlineSeller.isOnline()) {
+                var expiration = configuration.getExpireExpiration().getExpiration(offlineSeller.getPlayer());
+                applyExpiration.accept(expiration);
+            } else {
+                configuration.getExpireExpiration().getExpiration(this.plugin.getOfflinePermission(), offlineSeller)
+                        .whenComplete((expiration, throwable) -> {
+                            long safeExpiration = expiration != null ? expiration : configuration.getExpireExpiration().defaultExpiration();
+                            if (throwable != null) {
+                                this.plugin.getLogger().log(Level.WARNING, "Cannot compute expiration for offline player " + offlineSeller.getName(), throwable);
+                            }
+                            applyExpiration.accept(safeExpiration);
+                        });
+            }
 
         } else {
 


### PR DESCRIPTION
## Summary
- update OfflinePermission to return a CompletableFuture and adjust offline permission implementations
- compute expiration times asynchronously for offline players before moving items to expired storage

## Testing
- bash ./gradlew test *(fails: Unable to tunnel through proxy; HTTP 403 during Gradle download)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6925a72b2dfc8321b13ef9ce9d0d040e)