### PR TITLE
Await storage updates during item removal

### DIFF
--- a/API/src/main/java/fr/maxlego08/zauctionhouse/api/AuctionManager.java
+++ b/API/src/main/java/fr/maxlego08/zauctionhouse/api/AuctionManager.java
@@ -65,13 +65,13 @@ public interface AuctionManager {
 
     void removeCache(Player player);
 
-    void removeListedItem(Player player, Item item);
+    java.util.concurrent.CompletableFuture<Void> removeListedItem(Player player, Item item);
 
-    void removeOwnedItem(Player player, Item item);
+    java.util.concurrent.CompletableFuture<Void> removeOwnedItem(Player player, Item item);
 
-    void removeExpiredItem(Player player, Item item);
+    java.util.concurrent.CompletableFuture<Void> removeExpiredItem(Player player, Item item);
 
-    void removePurchasedItem(Player player, Item item);
+    java.util.concurrent.CompletableFuture<Void> removePurchasedItem(Player player, Item item);
 
     void adminRemoveItem(Player admin, java.util.UUID targetUniqueId, Item item, StorageType storageType);
 

--- a/API/src/main/java/fr/maxlego08/zauctionhouse/api/services/AuctionRemoveService.java
+++ b/API/src/main/java/fr/maxlego08/zauctionhouse/api/services/AuctionRemoveService.java
@@ -5,12 +5,12 @@ import org.bukkit.entity.Player;
 
 public interface AuctionRemoveService {
 
-    void removeListedItem(Player player, Item item);
+    java.util.concurrent.CompletableFuture<Void> removeListedItem(Player player, Item item);
 
-    void removeOwnedItem(Player player, Item item);
+    java.util.concurrent.CompletableFuture<Void> removeOwnedItem(Player player, Item item);
 
-    void removeExpiredItem(Player player, Item item);
+    java.util.concurrent.CompletableFuture<Void> removeExpiredItem(Player player, Item item);
 
-    void removePurchasedItem(Player player, Item item);
+    java.util.concurrent.CompletableFuture<Void> removePurchasedItem(Player player, Item item);
 
 }

--- a/API/src/main/java/fr/maxlego08/zauctionhouse/api/storage/StorageManager.java
+++ b/API/src/main/java/fr/maxlego08/zauctionhouse/api/storage/StorageManager.java
@@ -27,7 +27,7 @@ public interface StorageManager {
 
     <T extends Repository> T with(Class<T> module);
 
-    void updateItem(Item item, StorageType storageType);
+    java.util.concurrent.CompletableFuture<Void> updateItem(Item item, StorageType storageType);
 
     void log(LogType logType, int itemId, Player player, UUID targetUniqueId, BigDecimal price, String economyName, String additionalData);
 

--- a/src/main/java/fr/maxlego08/zauctionhouse/ZAuctionManager.java
+++ b/src/main/java/fr/maxlego08/zauctionhouse/ZAuctionManager.java
@@ -223,7 +223,7 @@ public class ZAuctionManager extends ZUtils implements AuctionManager {
     }
 
     @Override
-    public void removeListedItem(Player player, Item item) {
+    public CompletableFuture<Void> removeListedItem(Player player, Item item) {
 
         var configuration = this.plugin.getConfiguration();
         var storageManager = this.plugin.getStorageManager();
@@ -234,9 +234,11 @@ public class ZAuctionManager extends ZUtils implements AuctionManager {
         this.updateListedItems(item, false, player);
         clearPlayerCache(player, PlayerCacheKey.ITEMS_OWNED, PlayerCacheKey.ITEMS_EXPIRED); // Suppression du cache du joueur
 
+        CompletableFuture<Void> updateFuture;
+
         if (configuration.getActions().listed().giveItem() && item.canReceiveItem(player)) {
 
-            storageManager.updateItem(item, StorageType.DELETED);
+            updateFuture = storageManager.updateItem(item, StorageType.DELETED);
             giveItem(player, item);
 
         } else {
@@ -246,7 +248,7 @@ public class ZAuctionManager extends ZUtils implements AuctionManager {
             item.setExpiredAt(new Date(expiredAt));
 
             addItem(StorageType.EXPIRED, item);
-            storageManager.updateItem(item, StorageType.EXPIRED);
+            updateFuture = storageManager.updateItem(item, StorageType.EXPIRED);
         }
 
         message(this.plugin, player, Message.ITEM_REMOVE_LISTED, "%items%", item.getItemDisplay());
@@ -260,10 +262,12 @@ public class ZAuctionManager extends ZUtils implements AuctionManager {
         callEvent(new AuctionRemoveListedItemEvent(item, player));
 
         logItemAction(LogType.REMOVE_LISTED, item, player, null, "removed_from_listed");
+
+        return updateFuture;
     }
 
     @Override
-    public void removeOwnedItem(Player player, Item item) {
+    public CompletableFuture<Void> removeOwnedItem(Player player, Item item) {
 
         var configuration = this.plugin.getConfiguration();
         var storageManager = this.plugin.getStorageManager();
@@ -274,7 +278,7 @@ public class ZAuctionManager extends ZUtils implements AuctionManager {
         this.updateListedItems(item, false, player);
         clearPlayerCache(player, PlayerCacheKey.ITEMS_OWNED, PlayerCacheKey.ITEMS_EXPIRED); // Suppression du cache du joueur
 
-        storageManager.updateItem(item, StorageType.DELETED);
+        var updateFuture = storageManager.updateItem(item, StorageType.DELETED);
         giveItem(player, item);
 
         message(this.plugin, player, Message.ITEM_REMOVE_OWNED, "%items%", item.getItemDisplay());
@@ -288,10 +292,12 @@ public class ZAuctionManager extends ZUtils implements AuctionManager {
         callEvent(new AuctionRemoveListedItemEvent(item, player));
 
         logItemAction(LogType.REMOVE_OWNED, item, player, null, "removed_owned_item");
+
+        return updateFuture;
     }
 
     @Override
-    public void removeExpiredItem(Player player, Item item) {
+    public CompletableFuture<Void> removeExpiredItem(Player player, Item item) {
 
         var configuration = this.plugin.getConfiguration();
         var storageManager = this.plugin.getStorageManager();
@@ -299,7 +305,7 @@ public class ZAuctionManager extends ZUtils implements AuctionManager {
         removeItem(StorageType.EXPIRED, item);
         clearPlayerCache(player, PlayerCacheKey.ITEMS_EXPIRED);
 
-        storageManager.updateItem(item, StorageType.DELETED);
+        var updateFuture = storageManager.updateItem(item, StorageType.DELETED);
         giveItem(player, item);
 
         message(this.plugin, player, Message.ITEM_REMOVE_EXPIRED, "%items%", item.getItemDisplay());
@@ -313,10 +319,12 @@ public class ZAuctionManager extends ZUtils implements AuctionManager {
         callEvent(new AuctionRemoveExpiredItemEvent(item, player));
 
         logItemAction(LogType.REMOVE_EXPIRED, item, player, null, "removed_expired_item");
+
+        return updateFuture;
     }
 
     @Override
-    public void removePurchasedItem(Player player, Item item) {
+    public CompletableFuture<Void> removePurchasedItem(Player player, Item item) {
 
         var configuration = this.plugin.getConfiguration();
         var storageManager = this.plugin.getStorageManager();
@@ -324,7 +332,7 @@ public class ZAuctionManager extends ZUtils implements AuctionManager {
         removeItem(StorageType.PURCHASED, item);
         clearPlayerCache(player, PlayerCacheKey.ITEMS_PURCHASED);
 
-        storageManager.updateItem(item, StorageType.DELETED);
+        var updateFuture = storageManager.updateItem(item, StorageType.DELETED);
         giveItem(player, item);
 
         message(this.plugin, player, Message.ITEM_REMOVE_PURCHASED, "%items%", item.getItemDisplay());
@@ -338,6 +346,8 @@ public class ZAuctionManager extends ZUtils implements AuctionManager {
         callEvent(new AuctionRemovePurchasedItemEvent(item, player));
 
         logItemAction(LogType.REMOVE_PURCHASED, item, player, item.getSellerUniqueId(), "removed_purchased_item");
+
+        return updateFuture;
 
     }
 

--- a/src/main/java/fr/maxlego08/zauctionhouse/services/RemoveService.java
+++ b/src/main/java/fr/maxlego08/zauctionhouse/services/RemoveService.java
@@ -2,7 +2,6 @@ package fr.maxlego08.zauctionhouse.services;
 
 import fr.maxlego08.zauctionhouse.api.AuctionPlugin;
 import fr.maxlego08.zauctionhouse.api.cache.PlayerCacheKey;
-import fr.maxlego08.zauctionhouse.api.cluster.LockToken;
 import fr.maxlego08.zauctionhouse.api.event.events.remove.AuctionPreRemoveExpiredItemEvent;
 import fr.maxlego08.zauctionhouse.api.event.events.remove.AuctionPreRemoveListedItemEvent;
 import fr.maxlego08.zauctionhouse.api.event.events.remove.AuctionPreRemovePurchasedItemEvent;
@@ -11,6 +10,9 @@ import fr.maxlego08.zauctionhouse.api.item.ItemStatus;
 import fr.maxlego08.zauctionhouse.api.item.StorageType;
 import fr.maxlego08.zauctionhouse.api.services.AuctionRemoveService;
 import org.bukkit.entity.Player;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Supplier;
 
 public class RemoveService extends AuctionService implements AuctionRemoveService {
 
@@ -21,10 +23,10 @@ public class RemoveService extends AuctionService implements AuctionRemoveServic
     }
 
     @Override
-    public void removeListedItem(Player player, Item item) {
+    public CompletableFuture<Void> removeListedItem(Player player, Item item) {
 
         var event = new AuctionPreRemoveListedItemEvent(item, player);
-        if (!event.callEvent()) return;
+        if (!event.callEvent()) return CompletableFuture.completedFuture(null);
 
         var auctionManager = this.plugin.getAuctionManager();
         var inventoryManager = this.plugin.getInventoriesLoader().getInventoryManager();
@@ -35,27 +37,27 @@ public class RemoveService extends AuctionService implements AuctionRemoveServic
             logger.info("Item expired");
             auctionManager.getCache(player).remove(PlayerCacheKey.ITEMS_LISTED);
             auctionManager.openMainAuction(player);
-            return;
+            return CompletableFuture.completedFuture(null);
         }
 
         if (item.getStatus() != ItemStatus.AVAILABLE) {
             logger.info("Item not available");
             auctionManager.openMainAuction(player);
-            return;
+            return CompletableFuture.completedFuture(null);
         }
 
         item.setStatus(ItemStatus.IS_BEING_REMOVED);
 
         // 2. Vérifier si l'item est lock
-        executeRemoval(player, item, () -> inventoryManager.updateInventory(player), () -> auctionManager.removeListedItem(player, item), StorageType.LISTED);
+        return executeRemoval(player, item, () -> inventoryManager.updateInventory(player), () -> auctionManager.removeListedItem(player, item), StorageType.LISTED);
     }
 
     @Override
-    public void removeOwnedItem(Player player, Item item) {
+    public CompletableFuture<Void> removeOwnedItem(Player player, Item item) {
 
 
         var event = new AuctionPreRemoveListedItemEvent(item, player);
-        if (!event.callEvent()) return;
+        if (!event.callEvent()) return CompletableFuture.completedFuture(null);
 
         var auctionManager = this.plugin.getAuctionManager();
         var inventoryManager = this.plugin.getInventoriesLoader().getInventoryManager();
@@ -66,27 +68,27 @@ public class RemoveService extends AuctionService implements AuctionRemoveServic
             logger.info("Item expired");
             auctionManager.getCache(player).remove(PlayerCacheKey.ITEMS_LISTED);
             auctionManager.openMainAuction(player);
-            return;
+            return CompletableFuture.completedFuture(null);
         }
 
         if (item.getStatus() != ItemStatus.AVAILABLE) {
             logger.info("Item not available");
             auctionManager.openMainAuction(player);
-            return;
+            return CompletableFuture.completedFuture(null);
         }
 
         item.setStatus(ItemStatus.IS_BEING_REMOVED);
 
         // 2. Vérifier si l'item est lock
-        executeRemoval(player, item, () -> inventoryManager.updateInventory(player), () -> auctionManager.removeOwnedItem(player, item), StorageType.LISTED);
+        return executeRemoval(player, item, () -> inventoryManager.updateInventory(player), () -> auctionManager.removeOwnedItem(player, item), StorageType.LISTED);
 
     }
 
     @Override
-    public void removeExpiredItem(Player player, Item item) {
+    public CompletableFuture<Void> removeExpiredItem(Player player, Item item) {
 
         var event = new AuctionPreRemoveExpiredItemEvent(item, player);
-        if (!event.callEvent()) return;
+        if (!event.callEvent()) return CompletableFuture.completedFuture(null);
 
         var auctionManager = this.plugin.getAuctionManager();
         var inventoryManager = this.plugin.getInventoriesLoader().getInventoryManager();
@@ -97,26 +99,26 @@ public class RemoveService extends AuctionService implements AuctionRemoveServic
             logger.info("Item expired");
             auctionManager.getCache(player).remove(PlayerCacheKey.ITEMS_EXPIRED);
             inventoryManager.updateInventory(player);
-            return;
+            return CompletableFuture.completedFuture(null);
         }
 
         if (item.getStatus() != ItemStatus.REMOVED) {
             logger.info("Item not available");
             inventoryManager.updateInventory(player);
-            return;
+            return CompletableFuture.completedFuture(null);
         }
 
         item.setStatus(ItemStatus.DELETED);
 
         // 2. Vérifier si l'item est lock
-        executeRemoval(player, item, () -> inventoryManager.updateInventory(player), () -> this.plugin.getAuctionManager().removeExpiredItem(player, item), StorageType.EXPIRED);
+        return executeRemoval(player, item, () -> inventoryManager.updateInventory(player), () -> this.plugin.getAuctionManager().removeExpiredItem(player, item), StorageType.EXPIRED);
     }
 
     @Override
-    public void removePurchasedItem(Player player, Item item) {
+    public CompletableFuture<Void> removePurchasedItem(Player player, Item item) {
 
         var event = new AuctionPreRemovePurchasedItemEvent(item, player);
-        if (!event.callEvent()) return;
+        if (!event.callEvent()) return CompletableFuture.completedFuture(null);
 
         var auctionManager = this.plugin.getAuctionManager();
         var inventoryManager = this.plugin.getInventoriesLoader().getInventoryManager();
@@ -127,28 +129,28 @@ public class RemoveService extends AuctionService implements AuctionRemoveServic
             logger.info("Item expired");
             auctionManager.getCache(player).remove(PlayerCacheKey.ITEMS_EXPIRED);
             inventoryManager.updateInventory(player);
-            return;
+            return CompletableFuture.completedFuture(null);
         }
 
         if (item.getStatus() != ItemStatus.PURCHASED) {
             logger.info("Item not available");
             inventoryManager.updateInventory(player);
-            return;
+            return CompletableFuture.completedFuture(null);
         }
 
         item.setStatus(ItemStatus.DELETED);
 
         var manager = this.plugin.getAuctionManager();
-        executeRemoval(player, item, () -> manager.updateInventory(player), () -> manager.removePurchasedItem(player, item), StorageType.PURCHASED);
+        return executeRemoval(player, item, () -> manager.updateInventory(player), () -> manager.removePurchasedItem(player, item), StorageType.PURCHASED);
 
     }
 
-    private void executeRemoval(Player player, Item item, Runnable onUnavailable, Runnable onLocalRemoval, StorageType storageType) {
+    private CompletableFuture<Void> executeRemoval(Player player, Item item, Runnable onUnavailable, Supplier<CompletableFuture<Void>> onLocalRemoval, StorageType storageType) {
 
         var clusterBridge = this.plugin.getAuctionClusterBridge();
         var logger = this.plugin.getLogger();
 
-        clusterBridge.checkAvailability(item).thenCompose(available -> {
+        return clusterBridge.checkAvailability(item).thenCompose(available -> {
 
             if (!available) {
                 logger.info("Item is not available");
@@ -158,22 +160,12 @@ public class RemoveService extends AuctionService implements AuctionRemoveServic
 
             return clusterBridge.lockItem(item, player.getUniqueId());
 
-        }).thenCompose(token -> {
-
-            // 3. On va supprimer l'item coté REDIS
-
-            logger.info("Token: " + token);
-            return clusterBridge.removeItem(item, storageType);
-
-        }).thenCompose(v -> {
-
-            // 4. On supprime l'item en local
-            onLocalRemoval.run();
-
-            return clusterBridge.unlockItem(item, LockToken.of(item));
-        }).exceptionally(e -> {
-            e.printStackTrace();
-            return null;
-        });
+        }).thenCompose(token -> onLocalRemoval.get()
+                .thenCompose(v -> clusterBridge.removeItem(item, storageType)
+                        .thenCompose(vv -> clusterBridge.unlockItem(item, token))))
+                .exceptionally(e -> {
+                    e.printStackTrace();
+                    return null;
+                });
     }
 }

--- a/src/main/java/fr/maxlego08/zauctionhouse/storage/ZStorageManager.java
+++ b/src/main/java/fr/maxlego08/zauctionhouse/storage/ZStorageManager.java
@@ -137,8 +137,8 @@ public class ZStorageManager implements StorageManager {
     }
 
     @Override
-    public void updateItem(Item item, StorageType storageType) {
-        async(() -> with(ItemRepository.class).updateItem(item, storageType));
+    public CompletableFuture<Void> updateItem(Item item, StorageType storageType) {
+        return CompletableFuture.runAsync(() -> with(ItemRepository.class).updateItem(item, storageType), this.plugin.getExecutorService());
     }
 
     @Override


### PR DESCRIPTION
## Summary
- change auction removal APIs to return CompletableFuture<Void> and propagate through manager and services
- run storage updates on CompletableFutures so removal flows wait for SQL before redis removal
- adjust removal execution order to await database updates before removing items from redis

## Testing
- ./gradlew test


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693037f858388321a6a6e9b894557818)