### PR TITLE
Add detailed Javadoc to API interfaces

### DIFF
--- a/API/src/main/java/fr/maxlego08/zauctionhouse/api/AuctionManager.java
+++ b/API/src/main/java/fr/maxlego08/zauctionhouse/api/AuctionManager.java
@@ -16,69 +16,281 @@ import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Predicate;
 
+/**
+ * Central entry point for manipulating the auction house state. Implementations coordinate UI
+ * opening, item storage, cache management, and asynchronous item lifecycle actions so that other
+ * plugins can interact with the marketplace without duplicating logic.
+ */
 public interface AuctionManager {
 
+    /**
+     * Opens the main auction house inventory for the provided player using the default first page
+     * configuration.
+     *
+     * @param player viewer who should see the main auction interface
+     */
     void openMainAuction(Player player);
 
+    /**
+     * Opens the main auction house inventory at a specific page for pagination-aware UIs.
+     *
+     * @param player viewer who should see the main auction interface
+     * @param page   zero or one based page index depending on the configured inventory provider
+     */
     void openMainAuction(Player player, int page);
 
+    /**
+     * Forces the currently opened auction inventory of the player to refresh its contents and UI
+     * components. Implementations typically re-run pagination and sorting logic before redrawing
+     * the view.
+     *
+     * @param player player whose auction inventory should be updated
+     */
     void updateInventory(Player player);
 
+    /**
+     * @return service responsible for processing purchases and related validations
+     */
     AuctionPurchaseService getPurchaseService();
 
+    /**
+     * @return service used to list items for sale and validate prices or player limits
+     */
     AuctionSellService getSellService();
 
+    /**
+     * @return service coordinating removal of items from storage or live listings
+     */
     AuctionRemoveService getRemoveService();
 
+    /**
+     * @return service that moves items into expired storage and notifies owners when applicable
+     */
     AuctionExpireService getExpireService();
 
+    /**
+     * Retrieves every item stored under the given bucket (listed, expired, purchased, etc.).
+     *
+     * @param storageType logical container to read from
+     * @return immutable or defensive copy list of items currently recorded for that storage type
+     */
     List<Item> getItems(StorageType storageType);
 
+    /**
+     * Retrieves items from the given storage type and filters them before returning. Filtering is
+     * executed synchronously on the current thread and should remain inexpensive.
+     *
+     * @param storageType logical container to read from
+     * @param predicate   filter applied to each candidate item
+     * @return list of items that satisfy the predicate
+     */
     List<Item> getItems(StorageType storageType, Predicate<Item> predicate);
 
+    /**
+     * Retrieves, filters, and sorts items from the given storage type in one pass to support
+     * inventory rendering and API consumers that require deterministic ordering.
+     *
+     * @param storageType logical container to read from
+     * @param predicate   filter applied to each candidate item
+     * @param comparator  ordering applied to the filtered results
+     * @return sorted list of items that satisfy the predicate
+     */
     List<Item> getItems(StorageType storageType, Predicate<Item> predicate, Comparator<Item> comparator);
 
+    /**
+     * Adds a new item into the specified storage bucket. Implementations are responsible for
+     * persisting the item and updating any caches or live inventory views.
+     *
+     * @param storageType logical container to add the item to
+     * @param item        item instance to store
+     */
     void addItem(StorageType storageType, Item item);
 
+    /**
+     * Removes the provided item reference from the specified storage type if it exists.
+     *
+     * @param storageType storage bucket the item should be removed from
+     * @param item        item instance to delete
+     */
     void removeItem(StorageType storageType, Item item);
 
+    /**
+     * Removes an item identified by its unique ID from the specified storage type without
+     * requiring a full item instance.
+     *
+     * @param storageType storage bucket the item should be removed from
+     * @param itemId      unique identifier of the item to delete
+     */
     void removeItem(StorageType storageType, int itemId);
 
+    /**
+     * Retrieves every item currently listed for sale by the given player, excluding expired or
+     * purchased entries.
+     *
+     * @param player player who listed the items
+     * @return list of active listings created by the player
+     */
     List<Item> getItemsListedForSale(Player player);
 
+    /**
+     * Retrieves expired listings that belong to the specified player so they can reclaim them.
+     *
+     * @param player player owner of the expired items
+     * @return expired items awaiting reclamation
+     */
     List<Item> getExpiredItems(Player player);
 
+    /**
+     * Retrieves items currently owned by the player but still within the auction house storage
+     * (for example, unsold items or items awaiting delivery).
+     *
+     * @param player player owner to search for
+     * @return items belonging to the player across storage types
+     */
     List<Item> getPlayerOwnedItems(Player player);
 
+    /**
+     * Retrieves items the player successfully purchased and that are held in storage until
+     * collected.
+     *
+     * @param player player who purchased the items
+     * @return purchased items awaiting delivery
+     */
     List<Item> getPurchasedItems(Player player);
 
+    /**
+     * Version of {@link #getExpiredItems(Player)} using a UUID for offline player compatibility.
+     *
+     * @param uniqueId unique identifier of the player
+     * @return expired items awaiting reclamation
+     */
     List<Item> getExpiredItems(java.util.UUID uniqueId);
 
+    /**
+     * Version of {@link #getPlayerOwnedItems(Player)} using a UUID for offline player support.
+     *
+     * @param uniqueId unique identifier of the player
+     * @return items belonging to the player across storage types
+     */
     List<Item> getPlayerOwnedItems(java.util.UUID uniqueId);
 
+    /**
+     * Version of {@link #getPurchasedItems(Player)} using a UUID for offline player support.
+     *
+     * @param uniqueId unique identifier of the player
+     * @return purchased items awaiting delivery
+     */
     List<Item> getPurchasedItems(java.util.UUID uniqueId);
 
+    /**
+     * Retrieves or initializes the cache entry associated with the given player, exposing
+     * frequently accessed player-specific data.
+     *
+     * @param player player whose cache should be retrieved
+     * @return cache wrapper providing quick access to player metadata
+     */
     PlayerCache getCache(Player player);
 
+    /**
+     * Clears the requested cache keys for every tracked player, forcing the values to be recomputed
+     * on next access.
+     *
+     * @param keys cache keys to reset; when empty all caches remain untouched
+     */
     void clearPlayersCache(PlayerCacheKey... keys);
 
+    /**
+     * Clears the requested cache keys for a specific player so the information will be recalculated
+     * the next time it is requested.
+     *
+     * @param player player whose cache should be purged
+     * @param keys   cache keys to reset; when empty no keys are cleared
+     */
     void clearPlayerCache(Player player, PlayerCacheKey... keys);
 
+    /**
+     * Removes the entire cache entry for a player, typically when they disconnect or no longer need
+     * to be tracked.
+     *
+     * @param player player whose cache should be removed
+     */
     void removeCache(Player player);
 
+    /**
+     * Asynchronously removes an item the player listed for sale, executing required storage and
+     * refund operations.
+     *
+     * @param player player requesting the removal
+     * @param item   listing to remove
+     * @return future completing once the removal has been processed
+     */
     CompletableFuture<Void> removeListedItem(Player player, Item item);
 
+    /**
+     * Asynchronously removes an item owned by the player from their storage, for example when they
+     * discard a reclaimed item.
+     *
+     * @param player player requesting the removal
+     * @param item   owned item to delete
+     * @return future completing once the removal has been processed
+     */
     CompletableFuture<Void> removeOwnedItem(Player player, Item item);
 
+    /**
+     * Asynchronously removes an expired item from the player's expired storage.
+     *
+     * @param player player requesting the removal
+     * @param item   expired item to delete
+     * @return future completing once the removal has been processed
+     */
     CompletableFuture<Void> removeExpiredItem(Player player, Item item);
 
+    /**
+     * Asynchronously removes a purchased item from the player's purchased storage.
+     *
+     * @param player player requesting the removal
+     * @param item   purchased item to delete
+     * @return future completing once the removal has been processed
+     */
     CompletableFuture<Void> removePurchasedItem(Player player, Item item);
 
+    /**
+     * Allows an administrator to remove an item that belongs to another player from any storage
+     * type. Implementations should log the action and respect configured permissions.
+     *
+     * @param admin            administrator performing the removal
+     * @param targetUniqueId   owner of the item
+     * @param item             item to remove
+     * @param storageType      storage bucket the item currently resides in
+     */
     void adminRemoveItem(Player admin, java.util.UUID targetUniqueId, Item item, StorageType storageType);
 
+    /**
+     * Attempts to purchase the provided item on behalf of the player. The returned future completes
+     * once validations, economy transactions, storage updates, and notifications are finished.
+     *
+     * @param player buyer initiating the purchase
+     * @param item   listing to buy
+     * @return future completing after the purchase workflow finishes
+     */
     CompletableFuture<Void> purchaseItem(Player player, Item item);
 
+    /**
+     * Sends a localized or parameterized message to the player using the plugin's messaging system.
+     *
+     * @param player recipient of the message
+     * @param message message descriptor to send
+     * @param args    optional parameters inserted into the message template
+     */
     void message(Player player, Message message, Object... args);
 
+    /**
+     * Propagates changes to an item currently listed for sale so viewers can see the update without
+     * reopening the interface.
+     *
+     * @param item          listing that changed
+     * @param added         {@code true} when the item was added, {@code false} when removed
+     * @param ignoredPlayer optional player who should not receive the update (e.g., action initiator)
+     */
     void updateListedItems(Item item, boolean added, Player ignoredPlayer);
 }

--- a/API/src/main/java/fr/maxlego08/zauctionhouse/api/AuctionPlugin.java
+++ b/API/src/main/java/fr/maxlego08/zauctionhouse/api/AuctionPlugin.java
@@ -12,44 +12,130 @@ import org.bukkit.plugin.Plugin;
 
 import java.util.concurrent.ExecutorService;
 
+/**
+ * Core access point exposed to external plugins. This interface mirrors the main plugin instance
+ * while surfacing strongly typed services such as storage, economy, inventory loading, and cluster
+ * synchronization. Implementations should return live services ready for immediate use after
+ * plugin initialization.
+ */
 public interface AuctionPlugin extends Plugin {
 
+    /**
+     * Reloads configuration files and dependent services without requiring a full server restart.
+     */
     void reload();
 
+    /**
+     * @return scheduler abstraction used to dispatch synchronous and asynchronous tasks
+     */
     PlatformScheduler getScheduler();
 
+    /**
+     * @return persistence layer handling database connections, migrations, and repositories
+     */
     StorageManager getStorageManager();
 
+    /**
+     * @return current runtime configuration snapshot
+     */
     Configuration getConfiguration();
 
+    /**
+     * @return central manager orchestrating auction logic and player interactions
+     */
     AuctionManager getAuctionManager();
 
+    /**
+     * @return loader capable of registering and opening inventory-based menus
+     */
     InventoriesLoader getInventoriesLoader();
 
+    /**
+     * @return manager providing access to registered economy implementations and formatting helpers
+     */
     EconomyManager getEconomyManager();
 
+    /**
+     * @return executor used for blocking operations such as disk or database I/O
+     */
     ExecutorService getExecutorService();
 
+    /**
+     * @return placeholder service that resolves custom tokens inside messages
+     */
     Placeholder getPlaceholder();
 
+    /**
+     * @return bridge used to synchronize auction data across clustered server instances
+     */
     AuctionClusterBridge getAuctionClusterBridge();
 
+    /**
+     * @return manager responsible for applying rule checks when items are listed or purchased
+     */
     ItemRuleManager getItemRuleManager();
 
+    /**
+     * Overrides the default cluster bridge at runtime, allowing integrations to swap transport
+     * mechanisms.
+     *
+     * @param auctionClusterBridge cluster bridge implementation to use
+     */
     void setAuctionClusterBridge(AuctionClusterBridge auctionClusterBridge);
 
+    /**
+     * @return helper used to evaluate permissions for offline players
+     */
     OfflinePermission getOfflinePermission();
 
+    /**
+     * Registers a custom offline permission checker.
+     *
+     * @param offlinePermission permission resolver to use
+     */
     void setOfflinePermission(OfflinePermission offlinePermission);
 
+    /**
+     * Checks whether a file embedded in the plugin jar exists.
+     *
+     * @param resourcePath path inside the jar
+     * @return {@code true} if the resource exists
+     */
     boolean resourceExist(String resourcePath);
 
+    /**
+     * Saves an embedded resource to disk.
+     *
+     * @param resourcePath path inside the jar
+     * @param toPath       filesystem target path
+     * @param replace      whether to overwrite an existing file
+     */
     void saveResource(String resourcePath, String toPath, boolean replace);
 
+    /**
+     * Saves or updates a configuration resource, optionally merging existing content.
+     *
+     * @param resourcePath path inside the jar
+     * @param toPath       filesystem target path
+     * @param replace      whether to overwrite an existing file
+     */
     void saveOrUpdateConfiguration(String resourcePath, String toPath, boolean replace);
 
+    /**
+     * Saves an embedded file to the plugin's data directory using the same path name.
+     *
+     * @param resourcePath path inside the jar
+     * @param saveOrUpdate {@code true} to merge with an existing file when possible
+     */
     void saveFile(String resourcePath, boolean saveOrUpdate);
 
+    /**
+     * Saves an embedded file to a custom location in the plugin's data directory.
+     *
+     * @param resourcePath path inside the jar
+     * @param toPath       filesystem target path
+     * @param saveOrUpdate {@code true} to merge with an existing file when possible
+     */
     void saveFile(String resourcePath, String toPath, boolean saveOrUpdate);
 
 }

--- a/API/src/main/java/fr/maxlego08/zauctionhouse/api/InventoriesLoader.java
+++ b/API/src/main/java/fr/maxlego08/zauctionhouse/api/InventoriesLoader.java
@@ -7,27 +7,83 @@ import org.bukkit.entity.Player;
 
 import java.io.File;
 
+/**
+ * Handles discovery and loading of every graphical inventory registered by the plugin, including
+ * associated patterns and reusable button configurations. Implementations encapsulate the loading
+ * strategy (filesystem, packaged defaults, caching) so integrations can simply request menus to be
+ * opened for players.
+ */
 public interface InventoriesLoader {
 
+    /**
+     * Loads all available inventories from the configured sources. This should be called during
+     * plugin startup before any menus are opened.
+     */
     void loadInventories();
 
+    /**
+     * Loads a single inventory definition from the provided file, updating the registry if it
+     * already existed.
+     *
+     * @param file serialized inventory definition to parse
+     */
     void loadInventory(File file);
 
+    /**
+     * Loads every configured pattern (slot layouts, decorations, etc.) that inventories can reuse.
+     */
     void loadPatterns();
 
+    /**
+     * Loads a specific pattern file and registers it for later inventory construction.
+     *
+     * @param file serialized pattern to parse
+     */
     void loadPattern(File file);
 
+    /**
+     * Loads reusable button configurations so inventories can reference them by key instead of
+     * duplicating definitions.
+     */
     void loadButtons();
 
+    /**
+     * Convenience method that sequentially loads buttons, patterns, and inventories. Intended for
+     * first-time initialization.
+     */
     void load();
 
+    /**
+     * Reloads every inventory-related resource from disk, replacing existing registrations so
+     * changes take effect without restarting the server.
+     */
     void reload();
 
+    /**
+     * @return the underlying inventory manager used to register and open menus
+     */
     InventoryManager getInventoryManager();
 
+    /**
+     * @return the button manager providing access to shared button definitions
+     */
     ButtonManager getButtonManager();
 
+    /**
+     * Opens the specified inventory for the player on its initial page.
+     *
+     * @param player      viewer who should see the menu
+     * @param inventories identifier of the inventory to open
+     */
     void openInventory(Player player, Inventories inventories);
 
+    /**
+     * Opens the specified inventory for the player at the requested page index, enabling
+     * pagination-aware navigation.
+     *
+     * @param player      viewer who should see the menu
+     * @param inventories identifier of the inventory to open
+     * @param page        page index to display
+     */
     void openInventory(Player player, Inventories inventories, int page);
 }

--- a/API/src/main/java/fr/maxlego08/zauctionhouse/api/cache/PlayerCache.java
+++ b/API/src/main/java/fr/maxlego08/zauctionhouse/api/cache/PlayerCache.java
@@ -2,20 +2,73 @@ package fr.maxlego08.zauctionhouse.api.cache;
 
 import java.util.function.Supplier;
 
+/**
+ * Represents a lightweight cache tied to a player, used to store frequently accessed values such
+ * as configuration flags, limits, or computed statistics. Implementations are expected to be
+ * thread-safe when accessed from asynchronous tasks interacting with the auction house.
+ */
 public interface PlayerCache {
 
+    /**
+     * Stores the provided value under the given key, overriding any previously cached entry.
+     *
+     * @param key   identifier describing the cached value
+     * @param value value to associate with the key
+     * @param <T>   type of the value being cached
+     */
     <T> void set(PlayerCacheKey key, T value);
 
+    /**
+     * Retrieves the value associated with the key or {@code null} when no value is cached.
+     *
+     * @param key identifier describing the cached value
+     * @param <T> expected type of the cached value
+     * @return cached value or {@code null}
+     */
     <T> T get(PlayerCacheKey key);
 
+    /**
+     * Retrieves the value associated with the key or returns the provided fallback when the cache is
+     * missing an entry for the key.
+     *
+     * @param key      identifier describing the cached value
+     * @param fallback value returned if nothing is cached
+     * @param <T>      expected type of the cached value
+     * @return cached value or the fallback
+     */
     <T> T get(PlayerCacheKey key, T fallback);
 
+    /**
+     * Checks whether a value is already cached for the given key.
+     *
+     * @param key identifier describing the cached value
+     * @return {@code true} if the cache contains the key, {@code false} otherwise
+     */
     boolean has(PlayerCacheKey key);
 
+    /**
+     * Removes the cached value for the given key.
+     *
+     * @param key identifier describing the cached value
+     */
     void remove(PlayerCacheKey key);
 
+    /**
+     * Removes multiple cached values at once.
+     *
+     * @param keys identifiers describing the cached values
+     */
     void remove(PlayerCacheKey... keys);
 
+    /**
+     * Retrieves a cached value if it exists or computes and stores a new value using the supplier
+     * when missing.
+     *
+     * @param key      identifier describing the cached value
+     * @param supplier computation executed when the value is absent
+     * @param <T>      expected type of the cached value
+     * @return existing or newly computed value
+     */
     <T> T getOrCompute(PlayerCacheKey key, Supplier<T> supplier);
 
 }

--- a/API/src/main/java/fr/maxlego08/zauctionhouse/api/cluster/AuctionClusterBridge.java
+++ b/API/src/main/java/fr/maxlego08/zauctionhouse/api/cluster/AuctionClusterBridge.java
@@ -8,19 +8,75 @@ import org.bukkit.entity.Player;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 
+/**
+ * Defines the contract used to synchronize auction house actions across multiple server instances.
+ * Implementations are responsible for coordinating locks and broadcasting state changes so that
+ * concurrent purchases remain consistent in clustered environments.
+ */
 public interface AuctionClusterBridge {
 
+    /**
+     * Checks whether the item can still be purchased across the cluster, preventing stale views.
+     *
+     * @param item item being evaluated
+     * @return future resolving to {@code true} if the item is still available
+     */
     CompletableFuture<Boolean> checkAvailability(Item item);
 
+    /**
+     * Attempts to lock the item for the given buyer in the specified storage context, preventing
+     * other servers from selling it simultaneously.
+     *
+     * @param item        item to lock
+     * @param buyerId     UUID of the buyer
+     * @param storageType storage bucket the item resides in
+     * @return future containing a lock token to be used when unlocking
+     */
     CompletableFuture<LockToken> lockItem(Item item, UUID buyerId, StorageType storageType);
 
+    /**
+     * Releases a previously acquired lock, allowing other nodes to act on the item again.
+     *
+     * @param item        item to unlock
+     * @param lockToken   token returned by {@link #lockItem(Item, UUID, StorageType)}
+     * @param storageType storage bucket the item resides in
+     * @return future completing once the unlock has been propagated
+     */
     CompletableFuture<Void> unlockItem(Item item, LockToken lockToken, StorageType storageType);
 
+    /**
+     * Notifies the cluster that a player bought an item so caches and live views can be updated.
+     *
+     * @param player buyer who completed the purchase
+     * @param item   item that was purchased
+     * @return future completing after the notification is processed
+     */
     CompletableFuture<Void> notifyItemBought(Player player, Item item);
 
+    /**
+     * Notifies the cluster that a new item has been listed for sale.
+     *
+     * @param item item that was listed
+     * @return future completing after the notification is processed
+     */
     CompletableFuture<Void> notifyItemListed(Item item);
 
+    /**
+     * Broadcasts a status change for an item so other nodes can mirror the new state.
+     *
+     * @param item      item whose status changed
+     * @param oldStatus previous status value
+     * @param newStatus new status value
+     * @return future completing after the notification is processed
+     */
     CompletableFuture<Void> notifyItemStatusChange(Item item, ItemStatus oldStatus, ItemStatus newStatus);
 
+    /**
+     * Removes an item from the specified storage type across the cluster.
+     *
+     * @param item        item to remove
+     * @param storageType storage bucket the item currently resides in
+     * @return future completing after the deletion is processed
+     */
     CompletableFuture<Void> removeItem(Item item, StorageType storageType);
 }

--- a/API/src/main/java/fr/maxlego08/zauctionhouse/api/economy/EconomyManager.java
+++ b/API/src/main/java/fr/maxlego08/zauctionhouse/api/economy/EconomyManager.java
@@ -7,25 +7,80 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 
+/**
+ * Central registry for every economy available to the auction house. Implementations coordinate
+ * registration, lookups, formatting utilities, and default economy selection depending on the
+ * auction item type being handled.
+ */
 public interface EconomyManager {
 
+    /**
+     * @return all economies currently registered with the plugin
+     */
     Collection<AuctionEconomy> getEconomies();
 
+    /**
+     * Registers a new economy provider. Duplicate names should be rejected.
+     *
+     * @param economy economy implementation to register
+     * @return {@code true} if the economy was added, {@code false} if it already existed
+     */
     boolean registerEconomy(AuctionEconomy economy);
 
+    /**
+     * Removes the specified economy provider from the registry.
+     *
+     * @param economy economy implementation to remove
+     * @return {@code true} if the economy was removed
+     */
     boolean removeEconomy(AuctionEconomy economy);
 
+    /**
+     * Retrieves an economy by its internal name.
+     *
+     * @param economyName unique name of the economy
+     * @return optional containing the economy when found
+     */
     Optional<AuctionEconomy> getEconomy(String economyName);
 
+    /**
+     * Reloads and registers economies from configuration or detected hooks.
+     */
     void loadEconomies();
 
+    /**
+     * Returns the economy that should be used when listing or purchasing the provided item type.
+     *
+     * @param itemType type of auction item being processed
+     * @return default economy configured for the item type
+     */
     AuctionEconomy getDefaultEconomy(ItemType itemType);
 
+    /**
+     * @return decimal format applied when converting prices to human readable strings
+     */
     DecimalFormat getPriceDecimalFormat();
 
+    /**
+     * @return collection of number format reductions used to simplify large values (e.g., K, M)
+     */
     List<NumberFormatReduction> getPriceReductions();
 
+    /**
+     * Formats a number using a specific price format, applying reductions when necessary.
+     *
+     * @param priceFormat configuration describing how numbers should be represented
+     * @param number      numeric value to format
+     * @return formatted price string
+     */
     String format(PriceFormat priceFormat, Number number);
 
+    /**
+     * Formats a number using the rules defined by the provided economy instance.
+     *
+     * @param economy economy that owns the currency representation
+     * @param number  numeric value to format
+     * @return formatted price string
+     */
     String format(AuctionEconomy economy, Number number);
 }

--- a/API/src/main/java/fr/maxlego08/zauctionhouse/api/item/Item.java
+++ b/API/src/main/java/fr/maxlego08/zauctionhouse/api/item/Item.java
@@ -11,61 +11,176 @@ import java.util.Date;
 import java.util.List;
 import java.util.UUID;
 
+/**
+ * Abstraction representing an item tracked by the auction house, including metadata about the
+ * seller, buyer, pricing, and display state. Implementations should remain immutable wherever
+ * possible to avoid synchronization issues when items are viewed concurrently.
+ */
 public interface Item {
 
+    /**
+     * @return unique identifier of the item in storage
+     */
     int getId();
 
+    /**
+     * @return name of the server where the item originated (useful for clustered deployments)
+     */
     String getServerName();
 
+    /**
+     * @return UUID of the player who listed the item
+     */
     UUID getSellerUniqueId();
 
+    /**
+     * @return last known username of the seller
+     */
     String getSellerName();
 
+    /**
+     * @return listing price for the item
+     */
     BigDecimal getPrice();
 
+    /**
+     * @return economy used to process the transaction for this item
+     */
     AuctionEconomy getAuctionEconomy();
 
+    /**
+     * @return {@link OfflinePlayer} representation of the seller for compatibility with hooks
+     */
     OfflinePlayer getSeller();
 
+    /**
+     * @return timestamp when the item should expire from listings
+     */
     Date getExpiredAt();
 
+    /**
+     * Updates the expiration timestamp, typically when extending or reducing listing duration.
+     *
+     * @param expiredAt new expiration date
+     */
     void setExpiredAt(Date expiredAt);
 
+    /**
+     * @return timestamp when the item was originally listed
+     */
     Date getCreatedAt();
 
+    /**
+     * Builds the visual {@link ItemStack} representation tailored to the viewer.
+     *
+     * @param player viewer for whom the item is being rendered
+     * @return item stack with placeholders resolved for the player
+     */
     ItemStack buildItemStack(Player player);
 
+    /**
+     * Builds the visual {@link ItemStack} representation using custom lore lines.
+     *
+     * @param player viewer for whom the item is being rendered
+     * @param lore   lore lines to inject into the item display
+     * @return item stack with placeholders resolved for the player
+     */
     ItemStack buildItemStack(Player player, List<String> lore);
 
+    /**
+     * Creates placeholder values for the item so they can be substituted into menus or messages.
+     *
+     * @param player viewer or actor requesting placeholder data
+     * @return placeholder instance containing item-specific tokens
+     */
     Placeholders createPlaceholders(Player player);
 
+    /**
+     * Generates the textual status of the item (e.g., listed, expired) personalized for the player.
+     *
+     * @param player viewer requesting the status
+     * @return human-readable status string
+     */
     String createStatus(Player player);
 
+    /**
+     * @return price formatted using the associated economy
+     */
     String getFormattedPrice();
 
+    /**
+     * @return formatted expiration date string respecting the plugin's date format
+     */
     String getFormattedExpireDate();
 
+    /**
+     * @return human friendly representation of remaining time until expiration
+     */
     String getRemainingTime();
 
+    /**
+     * @return {@code true} if the current time is after the expiration date
+     */
     boolean isExpired();
 
+    /**
+     * @return current lifecycle status of the item
+     */
     ItemStatus getStatus();
 
+    /**
+     * Updates the lifecycle status (listed, expired, purchased, etc.).
+     *
+     * @param status new status to set
+     */
     void setStatus(ItemStatus status);
 
+    /**
+     * Indicates whether the player is allowed to receive the physical item stack (e.g., has
+     * inventory space or permissions).
+     *
+     * @param player player attempting to receive the item
+     * @return {@code true} if the player can receive the item
+     */
     boolean canReceiveItem(Player player);
 
+    /**
+     * @return quantity of items represented by this listing
+     */
     int getAmount();
 
+    /**
+     * @return translation key used to fetch localized display strings
+     */
     String getTranslationKey();
 
+    /**
+     * @return UUID of the buyer when the item has been purchased, otherwise {@code null}
+     */
     UUID getBuyerUniqueId();
 
+    /**
+     * @return last known username of the buyer
+     */
     String getBuyerName();
 
+    /**
+     * Records the buyer using a live {@link Player} reference.
+     *
+     * @param player buyer who purchased the item
+     */
     void setBuyer(Player player);
 
+    /**
+     * Records the buyer using pre-fetched identifiers, useful for offline transactions.
+     *
+     * @param buyerUniqueId UUID of the buyer
+     * @param buyerName     username of the buyer
+     */
     void setBuyer(UUID buyerUniqueId, String buyerName);
 
+    /**
+     * @return human-friendly display name of the item for menus and messages
+     */
     String getItemDisplay();
 }

--- a/API/src/main/java/fr/maxlego08/zauctionhouse/api/storage/StorageManager.java
+++ b/API/src/main/java/fr/maxlego08/zauctionhouse/api/storage/StorageManager.java
@@ -13,23 +13,85 @@ import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 
+/**
+ * Coordinates persistence concerns for the auction house such as loading listings, creating new
+ * records, and logging transactions. Implementations abstract the underlying data source
+ * (SQL, flat files, etc.) while providing asynchronous operations for expensive tasks.
+ */
 public interface StorageManager {
 
+    /**
+     * Initializes the storage layer, establishing connections or creating schema as needed.
+     *
+     * @return {@code true} if initialization succeeded and the plugin may continue loading
+     */
     boolean onEnable();
 
+    /**
+     * Gracefully shuts down the storage layer, closing connections and flushing pending writes.
+     */
     void onDisable();
 
+    /**
+     * Loads all stored items into memory caches to make them available for listings and lookups.
+     */
     void loadItems();
 
+    /**
+     * Inserts or updates the player entry to ensure ownership and statistics are tracked.
+     *
+     * @param player player to synchronize with storage
+     */
     void upsertPlayer(Player player);
 
+    /**
+     * Creates and persists a new auction item record.
+     *
+     * @param seller        player listing the item
+     * @param price         price of the listing
+     * @param expiredAt     expiration timestamp in milliseconds
+     * @param itemStacks    item stacks being sold
+     * @param auctionEconomy economy to use for the listing
+     * @return future containing the created {@link AuctionItem}
+     */
     CompletableFuture<AuctionItem> createAuctionItem(Player seller, BigDecimal price, long expiredAt, List<ItemStack> itemStacks, AuctionEconomy auctionEconomy);
 
+    /**
+     * Provides access to a specific repository module backed by the storage manager.
+     *
+     * @param module repository class to retrieve
+     * @param <T>    repository type
+     * @return repository instance
+     */
     <T extends Repository> T with(Class<T> module);
 
+    /**
+     * Updates the stored representation of the given item in the specified storage bucket.
+     *
+     * @param item        item to update
+     * @param storageType storage bucket where the item currently resides
+     * @return future completing when the update is persisted
+     */
     java.util.concurrent.CompletableFuture<Void> updateItem(Item item, StorageType storageType);
 
+    /**
+     * Records an audit log entry describing an action performed on an item.
+     *
+     * @param logType       type of log entry to create
+     * @param itemId        identifier of the affected item
+     * @param player        actor performing the action
+     * @param targetUniqueId secondary player involved, if any
+     * @param price         price related to the action
+     * @param economyName   economy used for the transaction
+     * @param additionalData extra serialized data for the log entry
+     */
     void log(LogType logType, int itemId, Player player, UUID targetUniqueId, BigDecimal price, String economyName, String additionalData);
 
+    /**
+     * Retrieves a single item from storage by its identifier.
+     *
+     * @param id item identifier
+     * @return future containing the item when found or {@code null} otherwise
+     */
     CompletableFuture<Item> selectItem(int id);
 }


### PR DESCRIPTION
## Summary
- add thorough English Javadocs to core API interfaces covering lifecycle, storage, economy, and clustering contracts
- document method responsibilities, parameters, and return values for auction items, caches, and inventories

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6936d65742c083218e8acc1f03c83aa0)