### PR TITLE
Add lite/full build variants with premium stubs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -113,6 +113,7 @@ gradle-app.setting
 .gradletasknamecache
 
 **/build/
+!src/**/build/
 
 # Common working directory
 run/

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,3 +1,6 @@
+import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
+import org.gradle.api.tasks.SourceSet
+import org.gradle.api.tasks.bundling.Jar
 import org.gradle.kotlin.dsl.invoke
 
 plugins {
@@ -41,6 +44,7 @@ allprojects {
     }
 
     java {
+        toolchain.languageVersion.set(JavaLanguageVersion.of(17))
         withSourcesJar()
         withJavadocJar()
     }
@@ -83,7 +87,125 @@ dependencies {
     api(projects.hooks)
 }
 
+val shadowPresent = plugins.hasPlugin("com.gradleup.shadow")
+
+sourceSets {
+    val main by getting
+
+    val lite by creating {
+        java.srcDir("src/lite/java")
+        resources.srcDir("src/lite/resources")
+        compileClasspath += main.output + configurations.getByName("compileClasspath")
+        runtimeClasspath += output + compileClasspath + main.output
+    }
+
+    val full by creating {
+        java.srcDir("src/full/java")
+        resources.srcDir("src/full/resources")
+        compileClasspath += main.output + configurations.getByName("compileClasspath")
+        runtimeClasspath += output + compileClasspath + main.output
+    }
+}
+
+configurations {
+    val implementation by getting
+    val compileOnly by getting
+    val runtimeOnly by getting
+
+    named("liteImplementation") { extendsFrom(implementation) }
+    named("liteCompileOnly") { extendsFrom(compileOnly) }
+    named("liteRuntimeOnly") { extendsFrom(runtimeOnly) }
+
+    named("fullImplementation") { extendsFrom(implementation) }
+    named("fullCompileOnly") { extendsFrom(compileOnly) }
+    named("fullRuntimeOnly") { extendsFrom(runtimeOnly) }
+}
+
+fun ShadowJar.configureVariant(variant: SourceSet, classifier: String) {
+    val runtimeClasspath = project.configurations.getByName("${variant.name}RuntimeClasspath")
+
+    archiveBaseName.set("zAuctionHouse")
+    archiveClassifier.set(classifier)
+    archiveAppendix.set("")
+
+    from(variant.output)
+    configurations.set(listOf(runtimeClasspath))
+
+    relocate("fr.maxlego08.sarah", "fr.maxlego08.zauctionhouse.libs.sarah")
+    relocate("com.tcoded.folialib", "fr.maxlego08.zauctionhouse.libs.folialib")
+    relocate("fr.traqueur.currencies", "fr.maxlego08.zauctionhouse.libs.currencies")
+
+    val baseClassifier = rootProject.extra.properties["classifier"] as String?
+    rootProject.extra.properties["sha"]?.let { sha ->
+        archiveClassifier.set(listOfNotNull(baseClassifier, classifier.takeIf { it.isNotBlank() }, sha.toString()).joinToString("-"))
+    } ?: run {
+        archiveClassifier.set(listOfNotNull(baseClassifier, classifier.takeIf { it.isNotBlank() }).joinToString("-"))
+    }
+    destinationDirectory.set(rootProject.extra["targetFolder"] as File)
+}
+
+fun Jar.configureVariant(variant: SourceSet, classifier: String) {
+    archiveBaseName.set("zAuctionHouse")
+    archiveClassifier.set(listOfNotNull(rootProject.extra.properties["classifier"] as String?, classifier.takeIf { it.isNotBlank() }).joinToString("-"))
+    archiveAppendix.set("")
+
+    from(variant.output)
+    destinationDirectory.set(rootProject.extra["targetFolder"] as File)
+}
+
 tasks {
+    compileJava {
+        options.release = 17
+    }
+
+    processResources {
+        from("resources")
+        filesMatching("plugin.yml") {
+            expand("version" to project.version)
+        }
+    }
+
+    val liteProcessResources = named<ProcessResources>("processLiteResources") {
+        filesMatching("plugin.yml") {
+            expand("version" to project.version)
+        }
+    }
+
+    val fullProcessResources = named<ProcessResources>("processFullResources") {
+        filesMatching("plugin.yml") {
+            expand("version" to project.version)
+        }
+    }
+    val liteJarTask = if (shadowPresent) {
+        register<ShadowJar>("shadowJarLite") {
+            dependsOn(liteProcessResources)
+            configureVariant(sourceSets.getByName("lite"), "lite")
+            from(sourceSets.main.get().output)
+            from(sourceSets.getByName("lite").output)
+        }
+    } else {
+        register<Jar>("jarLite") {
+            dependsOn(liteProcessResources)
+            configureVariant(sourceSets.getByName("lite"), "lite")
+            from(sourceSets.main.get().output)
+        }
+    }
+
+    val fullJarTask = if (shadowPresent) {
+        register<ShadowJar>("shadowJarFull") {
+            dependsOn(fullProcessResources)
+            configureVariant(sourceSets.getByName("full"), "full")
+            from(sourceSets.main.get().output)
+            from(sourceSets.getByName("full").output)
+        }
+    } else {
+        register<Jar>("jarFull") {
+            dependsOn(fullProcessResources)
+            configureVariant(sourceSets.getByName("full"), "full")
+            from(sourceSets.main.get().output)
+        }
+    }
+
     shadowJar {
 
         relocate("fr.maxlego08.sarah", "fr.maxlego08.zauctionhouse.libs.sarah")
@@ -99,17 +221,6 @@ tasks {
     }
 
     build {
-        dependsOn(shadowJar)
-    }
-
-    compileJava {
-        options.release = 21
-    }
-
-    processResources {
-        from("resources")
-        filesMatching("plugin.yml") {
-            expand("version" to project.version)
-        }
+        dependsOn(if (shadowPresent) listOf(shadowJar, liteJarTask, fullJarTask) else listOf(liteJarTask, fullJarTask))
     }
 }

--- a/readme.md
+++ b/readme.md
@@ -9,6 +9,15 @@ In a few months, you’ll be able to discover a plugin that’s even more comple
 more beautiful, fresher, more radiant, basically everything you could possibly want!
 It’s going to be amazing… or there will be bugs everywhere. Your call. 😄
 
+## Build variants
+
+Useful Gradle commands for the lite/full plugin builds:
+
+- `./gradlew jarLite`
+- `./gradlew jarFull`
+- `./gradlew build` (produces both jars)
+- If the Shadow plugin is available: `./gradlew shadowJarLite` / `./gradlew shadowJarFull`
+
 # ToDo
 
 - [ ] Retrailler le système de mise à jour de fichier YAML pour éviter d'ajouter n'importe comment les nouvelles clés, et garder une cohérence dans le fichier

--- a/src/full/java/fr/maxlego08/zauctionhouse/build/BuildTypeImpl.java
+++ b/src/full/java/fr/maxlego08/zauctionhouse/build/BuildTypeImpl.java
@@ -1,0 +1,9 @@
+package fr.maxlego08.zauctionhouse.build;
+
+public class BuildTypeImpl implements BuildType {
+
+    @Override
+    public boolean isPremium() {
+        return true;
+    }
+}

--- a/src/full/java/fr/maxlego08/zauctionhouse/premium/PremiumFeaturesImpl.java
+++ b/src/full/java/fr/maxlego08/zauctionhouse/premium/PremiumFeaturesImpl.java
@@ -1,0 +1,11 @@
+package fr.maxlego08.zauctionhouse.premium;
+
+import fr.maxlego08.zauctionhouse.ZAuctionPlugin;
+
+public class PremiumFeaturesImpl implements PremiumFeatures {
+
+    @Override
+    public void register(ZAuctionPlugin plugin) {
+        plugin.getLogger().info("Premium features registered for the full build.");
+    }
+}

--- a/src/full/resources/plugin.yml
+++ b/src/full/resources/plugin.yml
@@ -1,0 +1,13 @@
+name: zAuctionHouse
+version: ${version}
+main: fr.maxlego08.zauctionhouse.ZAuctionPlugin
+api-version: '1.21'
+authors: [ Maxlego08 ]
+description: Buy, resell, rent, bid your items!
+website: https://groupez.dev/
+folia-supported: true
+depend:
+  - zMenu
+  - PlaceholderAPI
+libraries:
+  - org.mariadb.jdbc:mariadb-java-client:3.5.6

--- a/src/lite/java/fr/maxlego08/zauctionhouse/build/BuildTypeImpl.java
+++ b/src/lite/java/fr/maxlego08/zauctionhouse/build/BuildTypeImpl.java
@@ -1,0 +1,9 @@
+package fr.maxlego08.zauctionhouse.build;
+
+public class BuildTypeImpl implements BuildType {
+
+    @Override
+    public boolean isPremium() {
+        return false;
+    }
+}

--- a/src/lite/java/fr/maxlego08/zauctionhouse/premium/PremiumFeaturesImpl.java
+++ b/src/lite/java/fr/maxlego08/zauctionhouse/premium/PremiumFeaturesImpl.java
@@ -1,0 +1,11 @@
+package fr.maxlego08.zauctionhouse.premium;
+
+import fr.maxlego08.zauctionhouse.ZAuctionPlugin;
+
+public class PremiumFeaturesImpl implements PremiumFeatures {
+
+    @Override
+    public void register(ZAuctionPlugin plugin) {
+        plugin.getLogger().info("Premium features are disabled in the lite build.");
+    }
+}

--- a/src/lite/resources/plugin.yml
+++ b/src/lite/resources/plugin.yml
@@ -1,0 +1,13 @@
+name: zAuctionHouse
+version: ${version}-LITE
+main: fr.maxlego08.zauctionhouse.ZAuctionPlugin
+api-version: '1.21'
+authors: [ Maxlego08 ]
+description: Buy, resell, rent, bid your items! (LITE)
+website: https://groupez.dev/
+folia-supported: true
+depend:
+  - zMenu
+  - PlaceholderAPI
+libraries:
+  - org.mariadb.jdbc:mariadb-java-client:3.5.6

--- a/src/main/java/fr/maxlego08/zauctionhouse/ZAuctionPlugin.java
+++ b/src/main/java/fr/maxlego08/zauctionhouse/ZAuctionPlugin.java
@@ -15,6 +15,7 @@ import fr.maxlego08.zauctionhouse.api.placeholders.PlaceholderRegister;
 import fr.maxlego08.zauctionhouse.api.rules.ItemRuleManager;
 import fr.maxlego08.zauctionhouse.api.storage.StorageManager;
 import fr.maxlego08.zauctionhouse.api.utils.Plugins;
+import fr.maxlego08.zauctionhouse.build.BuildType;
 import fr.maxlego08.zauctionhouse.cluster.LocalAuctionClusterBridge;
 import fr.maxlego08.zauctionhouse.command.CommandManager;
 import fr.maxlego08.zauctionhouse.command.commands.CommandAuction;
@@ -29,6 +30,7 @@ import fr.maxlego08.zauctionhouse.placeholder.DistantPlaceholder;
 import fr.maxlego08.zauctionhouse.placeholder.LocalPlaceholder;
 import fr.maxlego08.zauctionhouse.placeholder.placeholders.GlobalPlaceholders;
 import fr.maxlego08.zauctionhouse.placeholder.placeholders.PlayerPlaceholders;
+import fr.maxlego08.zauctionhouse.premium.PremiumFeatures;
 import fr.maxlego08.zauctionhouse.rule.ZItemRuleManager;
 import fr.maxlego08.zauctionhouse.storage.ZStorageManager;
 import org.bukkit.Bukkit;
@@ -64,6 +66,8 @@ public class ZAuctionPlugin extends JavaPlugin implements AuctionPlugin {
     private final ExecutorService asyncExecutor = Executors.newFixedThreadPool(4);
     private final Placeholder placeholder = new LocalPlaceholder(this);
     private final ItemRuleManager itemRuleManager = new ZItemRuleManager(this);
+    private final BuildType buildType = this.instantiate(BuildType.class, "fr.maxlego08.zauctionhouse.build.BuildTypeImpl");
+    private final PremiumFeatures premiumFeatures = this.instantiate(PremiumFeatures.class, "fr.maxlego08.zauctionhouse.premium.PremiumFeaturesImpl");
     private InventoriesLoader inventoriesLoader;
     private boolean isEnabled = false;
     private PlatformScheduler platformScheduler;
@@ -80,6 +84,9 @@ public class ZAuctionPlugin extends JavaPlugin implements AuctionPlugin {
 
         FoliaLib foliaLib = new FoliaLib(this);
         this.platformScheduler = foliaLib.getScheduler();
+
+        this.getLogger().info("Premium build: " + this.buildType.isPremium());
+        this.premiumFeatures.register(this);
 
         if (!this.storageManager.onEnable()) return;
 
@@ -213,6 +220,19 @@ public class ZAuctionPlugin extends JavaPlugin implements AuctionPlugin {
     @Override
     public Placeholder getPlaceholder() {
         return this.placeholder;
+    }
+
+    private <T> T instantiate(Class<T> type, String implClassName) {
+        try {
+            Class<?> clazz = Class.forName(implClassName);
+            Object instance = clazz.getDeclaredConstructor().newInstance();
+            if (!type.isInstance(instance)) {
+                throw new IllegalStateException(implClassName + " does not implement " + type.getSimpleName());
+            }
+            return type.cast(instance);
+        } catch (Exception exception) {
+            throw new IllegalStateException("Unable to instantiate " + implClassName, exception);
+        }
     }
 
     private void addListener(Listener listener) {

--- a/src/main/java/fr/maxlego08/zauctionhouse/build/BuildType.java
+++ b/src/main/java/fr/maxlego08/zauctionhouse/build/BuildType.java
@@ -1,0 +1,6 @@
+package fr.maxlego08.zauctionhouse.build;
+
+public interface BuildType {
+
+    boolean isPremium();
+}

--- a/src/main/java/fr/maxlego08/zauctionhouse/premium/PremiumFeatures.java
+++ b/src/main/java/fr/maxlego08/zauctionhouse/premium/PremiumFeatures.java
@@ -1,0 +1,8 @@
+package fr.maxlego08.zauctionhouse.premium;
+
+import fr.maxlego08.zauctionhouse.ZAuctionPlugin;
+
+public interface PremiumFeatures {
+
+    void register(ZAuctionPlugin plugin);
+}


### PR DESCRIPTION
## Summary
- add lite and full source sets with dedicated jar/shadowJar tasks and Java 17 toolchain
- introduce build type and premium feature interfaces with lite/full implementations wired into the plugin
- split plugin.yml resources per variant and document the gradle commands to build them

## Testing
- ./gradlew shadowJarLite --dry-run *(fails: Java 17 toolchain not provisioned in the environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695aaee600508321a80f00629add79e6)