### PR TITLE
Refactor PlayerCache type validation

### DIFF
--- a/API/src/main/java/fr/maxlego08/zauctionhouse/api/cache/PlayerCacheKey.java
+++ b/API/src/main/java/fr/maxlego08/zauctionhouse/api/cache/PlayerCacheKey.java
@@ -62,18 +62,24 @@ public enum PlayerCacheKey {
 
     private final TypeToken<?> type;
     private final Supplier<?> fallback;
+    private final Class<?> rawType;
 
     PlayerCacheKey(TypeToken<?> type, Supplier<?> fallback) {
         this.type = type;
         this.fallback = fallback;
+        this.rawType = type.getRawType();
     }
 
     public TypeToken<?> getType() {
-        return type;
+        return this.type;
+    }
+
+    public Class<?> getRawType() {
+        return this.rawType;
     }
 
     @SuppressWarnings("unchecked")
     public <T> T getFallback() {
-        return (T) fallback.get();
+        return (T) this.fallback.get();
     }
 }

--- a/src/main/java/fr/maxlego08/zauctionhouse/utils/cache/ZPlayerCache.java
+++ b/src/main/java/fr/maxlego08/zauctionhouse/utils/cache/ZPlayerCache.java
@@ -15,7 +15,7 @@ public class ZPlayerCache implements PlayerCache {
 
     @Override
     public <T> void set(PlayerCacheKey key, T value) {
-        if (!isValidType(key.getType().getType(), value)) {
+        if (value != null && !key.getRawType().isInstance(value)) {
             throw new IllegalArgumentException("Invalid type for key " + key + ": expected " + key.getType().getType());
         }
         this.cache.put(key, value);
@@ -47,21 +47,6 @@ public class ZPlayerCache implements PlayerCache {
         for (PlayerCacheKey key : keys) {
             this.cache.remove(key);
         }
-    }
-
-    private boolean isValidType(Type expected, Object value) {
-        if (value == null) return true;
-
-        if (expected instanceof Class<?>) {
-            return ((Class<?>) expected).isInstance(value);
-        }
-
-        if (expected instanceof ParameterizedType parameterized) {
-            Class<?> raw = (Class<?>) parameterized.getRawType();
-            return raw.isInstance(value);
-        }
-
-        return false;
     }
 
     @Override


### PR DESCRIPTION
Replace the custom isValidType() reflection logic with a pre-cached
rawType field on PlayerCacheKey, extracted once at enum init via
TypeToken.getRawType().

- Drop isValidType() in favor of key.getRawType().isInstance(value)