### PR TITLE
Fix SQLite schema bootstrap and legacy database detection

### DIFF
--- a/src/main/java/fr/maxlego08/zauctionhouse/storage/StorageSchemaDefinitions.java
+++ b/src/main/java/fr/maxlego08/zauctionhouse/storage/StorageSchemaDefinitions.java
@@ -1,0 +1,77 @@
+package fr.maxlego08.zauctionhouse.storage;
+
+import fr.maxlego08.sarah.database.Schema;
+import fr.maxlego08.zauctionhouse.api.item.StorageType;
+import fr.maxlego08.zauctionhouse.api.storage.Tables;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.function.Consumer;
+
+public final class StorageSchemaDefinitions {
+
+    private StorageSchemaDefinitions() {
+    }
+
+    public static Map<String, Consumer<Schema>> requiredTables() {
+        Map<String, Consumer<Schema>> tables = new LinkedHashMap<>();
+        tables.put(Tables.PLAYERS, StorageSchemaDefinitions::players);
+        tables.put(Tables.ITEMS, StorageSchemaDefinitions::items);
+        tables.put(Tables.AUCTION_ITEMS, StorageSchemaDefinitions::auctionItems);
+        tables.put(Tables.TRANSACTIONS, StorageSchemaDefinitions::transactions);
+        tables.put(Tables.LOGS, StorageSchemaDefinitions::logs);
+        return tables;
+    }
+
+    public static void players(Schema table) {
+        table.uuid("unique_id").primary().unique();
+        table.string("name", 16);
+        table.timestamps();
+    }
+
+    public static void items(Schema table) {
+        table.autoIncrement("id");
+        table.string("item_type", 255);
+        table.string("seller_unique_id", 36).foreignKey(Tables.PLAYERS, "unique_id", true);
+        table.string("buyer_unique_id", 36).nullable().foreignKey(Tables.PLAYERS, "unique_id", true);
+        table.decimal("price", 65, 2);
+        table.string("economy_name", 255);
+        table.enumType("storage_type", StorageType.class);
+        table.string("server_name", 255);
+        table.timestamp("expired_at");
+        table.timestamps();
+    }
+
+    public static void auctionItems(Schema table) {
+        table.autoIncrement("id");
+        table.integer("item_id").foreignKey(Tables.ITEMS, "id", true);
+        table.longText("itemstack");
+        table.timestamps();
+    }
+
+    public static void transactions(Schema table) {
+        table.autoIncrement("id");
+        table.integer("item_id").foreignKey(Tables.ITEMS, "id", true);
+        table.string("player_unique_id", 36).foreignKey(Tables.PLAYERS, "unique_id", true);
+        table.string("economy_name", 255);
+        table.decimal("before", 65, 2);
+        table.decimal("after", 65, 2);
+        table.decimal("value", 65, 2);
+        table.string("status", 32);
+        table.timestamps();
+    }
+
+    public static void logs(Schema table) {
+        table.autoIncrement("id");
+        table.integer("item_id").foreignKey(Tables.ITEMS, "id", true);
+        table.string("log_type", 255);
+        table.string("player_unique_id", 36).foreignKey(Tables.PLAYERS, "unique_id", true);
+        table.string("target_unique_id", 36).nullable().foreignKey(Tables.PLAYERS, "unique_id", true);
+        table.longText("itemstack").nullable();
+        table.decimal("price", 65, 2).defaultValue(0);
+        table.string("economy_name", 255).nullable();
+        table.longText("additional_data").nullable();
+        table.timestamp("readed_at").nullable();
+        table.timestamps();
+    }
+}

--- a/src/main/java/fr/maxlego08/zauctionhouse/storage/ZStorageManager.java
+++ b/src/main/java/fr/maxlego08/zauctionhouse/storage/ZStorageManager.java
@@ -39,6 +39,7 @@ public class ZStorageManager extends ItemLoaderUtils implements StorageManager {
 
     private static final String SQLITE_DATABASE_FILE = "database.db";
     private static final String SQLITE_LEGACY_DATABASE_FILE = "storage.db";
+    private static final String LEGACY_MIGRATION_TABLE = "zauctionhousev4_migrations";
 
     private final AuctionPlugin plugin;
     private AuctionLoader auctionLoader;
@@ -267,27 +268,72 @@ public class ZStorageManager extends ItemLoaderUtils implements StorageManager {
     }
 
     private String resolveMigrationTableName(String tablePrefix) {
-        return (tablePrefix == null ? "" : tablePrefix) + "migrations";
+        String newName = (tablePrefix == null ? "" : tablePrefix) + "migrations";
+
+        // If the legacy table still exists but the new prefix-derived table does not,
+        // keep using the legacy name so existing migration history is preserved.
+        if (rawTableExists(LEGACY_MIGRATION_TABLE) && !rawTableExists(newName)) {
+            this.plugin.getLogger().info(
+                    "Found legacy migration table '" + LEGACY_MIGRATION_TABLE
+                            + "'. Continuing to use it for backward compatibility.");
+            return LEGACY_MIGRATION_TABLE;
+        }
+
+        return newName;
     }
 
     private void ensureRequiredTablesExist(fr.maxlego08.sarah.logger.Logger logger) {
-        StorageSchemaDefinitions.requiredTables().forEach((tableName, definition) -> {
-            if (tableExists(tableName)) {
+        try (Connection connection = this.databaseConnection.getConnection()) {
+            DatabaseMetaData metaData = connection.getMetaData();
+            if (metaData == null) {
+                this.plugin.getLogger().warning("Database metadata is unavailable. Skipping table verification.");
                 return;
             }
 
-            String resolvedTableName = this.databaseConnection.getDatabaseConfiguration().replacePrefix(tableName);
-            this.plugin.getLogger().warning("Missing required table '" + resolvedTableName + "'. Recreating it now.");
-            try {
-                SchemaBuilder.create(null, tableName, definition).execute(this.databaseConnection, logger);
-            } catch (SQLException exception) {
-                throw new IllegalStateException("Failed to recreate missing table '" + resolvedTableName + "'", exception);
-            }
-        });
+            StorageSchemaDefinitions.requiredTables().forEach((tableName, definition) -> {
+                String resolvedTableName = this.databaseConnection.getDatabaseConfiguration().replacePrefix(tableName);
+
+                boolean exists;
+                try {
+                    exists = hasTable(metaData, connection, resolvedTableName)
+                            || hasTable(metaData, connection, resolvedTableName.toUpperCase(Locale.ROOT));
+                } catch (SQLException exception) {
+                    throw new IllegalStateException(
+                            "Cannot determine existence of table '" + resolvedTableName + "'. Aborting to prevent data corruption.",
+                            exception);
+                }
+
+                if (exists) {
+                    return;
+                }
+
+                this.plugin.getLogger().warning("Missing required table '" + resolvedTableName + "'. Recreating it now.");
+                try {
+                    SchemaBuilder.create(null, tableName, definition).execute(this.databaseConnection, logger);
+                } catch (SQLException exception) {
+                    throw new IllegalStateException("Failed to recreate missing table '" + resolvedTableName + "'", exception);
+                }
+            });
+        } catch (SQLException exception) {
+            throw new IllegalStateException("Failed to obtain database connection for table verification", exception);
+        }
     }
 
+    /**
+     * Checks whether a table exists using the configured table prefix to resolve the name.
+     * Throws on inspection failure to prevent accidental table recreation.
+     */
     private boolean tableExists(String tableName) {
         String resolvedTableName = this.databaseConnection.getDatabaseConfiguration().replacePrefix(tableName);
+        return rawTableExists(resolvedTableName);
+    }
+
+    /**
+     * Checks whether a table exists using the exact name provided (no prefix resolution).
+     * Used by the migration fallback where the table name is already fully qualified.
+     * Returns false on inspection failure (non-destructive context) with a warning log.
+     */
+    private boolean rawTableExists(String resolvedTableName) {
         try (Connection connection = this.databaseConnection.getConnection()) {
             DatabaseMetaData metaData = connection.getMetaData();
             if (metaData == null) {

--- a/src/main/java/fr/maxlego08/zauctionhouse/storage/ZStorageManager.java
+++ b/src/main/java/fr/maxlego08/zauctionhouse/storage/ZStorageManager.java
@@ -25,12 +25,20 @@ import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 import org.jetbrains.annotations.NotNull;
 
+import java.io.File;
+import java.sql.Connection;
+import java.sql.DatabaseMetaData;
+import java.sql.ResultSet;
+import java.sql.SQLException;
 import java.math.BigDecimal;
 import java.util.*;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 
 public class ZStorageManager extends ItemLoaderUtils implements StorageManager {
+
+    private static final String SQLITE_DATABASE_FILE = "database.db";
+    private static final String SQLITE_LEGACY_DATABASE_FILE = "storage.db";
 
     private final AuctionPlugin plugin;
     private AuctionLoader auctionLoader;
@@ -48,6 +56,9 @@ public class ZStorageManager extends ItemLoaderUtils implements StorageManager {
         var databaseConfiguration = this.getDatabaseConfiguration();
         var isSqlite = databaseConfiguration.getDatabaseType() == DatabaseType.SQLITE;
         this.databaseConnection = isSqlite ? new SqliteConnection(databaseConfiguration, this.plugin.getDataFolder(), sarahLogger) : new HikariDatabaseConnection(databaseConfiguration, sarahLogger);
+        if (isSqlite && this.databaseConnection instanceof SqliteConnection sqliteConnection) {
+            configureSqliteFile(sqliteConnection);
+        }
 
         if (!databaseConnection.isValid()) {
 
@@ -58,7 +69,7 @@ public class ZStorageManager extends ItemLoaderUtils implements StorageManager {
             this.plugin.getLogger().info("The database connection is valid !");
         }
 
-        MigrationManager.setMigrationTableName("zauctionhousev4_migrations");
+        MigrationManager.setMigrationTableName(resolveMigrationTableName(databaseConfiguration.getTablePrefix()));
         MigrationManager.setDatabaseConfiguration(databaseConfiguration);
 
         MigrationManager.registerMigration(new CreatePlayerMigration());
@@ -77,6 +88,7 @@ public class ZStorageManager extends ItemLoaderUtils implements StorageManager {
         this.repositories.register(TransactionRepository.class);
 
         MigrationManager.execute(this.databaseConnection, sarahLogger);
+        ensureRequiredTablesExist(sarahLogger);
 
         return true;
     }
@@ -238,5 +250,64 @@ public class ZStorageManager extends ItemLoaderUtils implements StorageManager {
     @Override
     public Map<UUID, String> selectPlayers(List<String> uuids) {
         return with(PlayerRepository.class).select(uuids).stream().collect(Collectors.toMap(PlayerDTO::unique_id, PlayerDTO::name));
+    }
+
+    private void configureSqliteFile(SqliteConnection sqliteConnection) {
+        File dataFolder = this.plugin.getDataFolder();
+        File currentFile = new File(dataFolder, SQLITE_DATABASE_FILE);
+        File legacyFile = new File(dataFolder, SQLITE_LEGACY_DATABASE_FILE);
+
+        if (legacyFile.exists() && !currentFile.exists()) {
+            sqliteConnection.setFileName(SQLITE_LEGACY_DATABASE_FILE);
+            this.plugin.getLogger().info("Using legacy SQLite database file: " + SQLITE_LEGACY_DATABASE_FILE);
+            return;
+        }
+
+        sqliteConnection.setFileName(SQLITE_DATABASE_FILE);
+    }
+
+    private String resolveMigrationTableName(String tablePrefix) {
+        return (tablePrefix == null ? "" : tablePrefix) + "migrations";
+    }
+
+    private void ensureRequiredTablesExist(fr.maxlego08.sarah.logger.Logger logger) {
+        StorageSchemaDefinitions.requiredTables().forEach((tableName, definition) -> {
+            if (tableExists(tableName)) {
+                return;
+            }
+
+            String resolvedTableName = this.databaseConnection.getDatabaseConfiguration().replacePrefix(tableName);
+            this.plugin.getLogger().warning("Missing required table '" + resolvedTableName + "'. Recreating it now.");
+            try {
+                SchemaBuilder.create(null, tableName, definition).execute(this.databaseConnection, logger);
+            } catch (SQLException exception) {
+                throw new IllegalStateException("Failed to recreate missing table '" + resolvedTableName + "'", exception);
+            }
+        });
+    }
+
+    private boolean tableExists(String tableName) {
+        String resolvedTableName = this.databaseConnection.getDatabaseConfiguration().replacePrefix(tableName);
+        try (Connection connection = this.databaseConnection.getConnection()) {
+            DatabaseMetaData metaData = connection.getMetaData();
+            if (metaData == null) {
+                return false;
+            }
+
+            if (hasTable(metaData, connection, resolvedTableName)) {
+                return true;
+            }
+
+            return hasTable(metaData, connection, resolvedTableName.toUpperCase(Locale.ROOT));
+        } catch (SQLException exception) {
+            this.plugin.getLogger().warning("Failed to inspect table '" + resolvedTableName + "': " + exception.getMessage());
+            return false;
+        }
+    }
+
+    private boolean hasTable(DatabaseMetaData metaData, Connection connection, String tableName) throws SQLException {
+        try (ResultSet resultSet = metaData.getTables(connection.getCatalog(), null, tableName, new String[]{"TABLE"})) {
+            return resultSet.next();
+        }
     }
 }

--- a/src/main/java/fr/maxlego08/zauctionhouse/storage/migrations/CreateAuctionItemMigration.java
+++ b/src/main/java/fr/maxlego08/zauctionhouse/storage/migrations/CreateAuctionItemMigration.java
@@ -2,16 +2,12 @@ package fr.maxlego08.zauctionhouse.storage.migrations;
 
 import fr.maxlego08.sarah.database.Migration;
 import fr.maxlego08.zauctionhouse.api.storage.Tables;
+import fr.maxlego08.zauctionhouse.storage.StorageSchemaDefinitions;
 
 public class CreateAuctionItemMigration extends Migration {
 
     @Override
     public void up() {
-        create(Tables.AUCTION_ITEMS, table -> {
-            table.autoIncrement("id");
-            table.integer("item_id").foreignKey(Tables.ITEMS, "id", true);
-            table.longText("itemstack");
-            table.timestamps();
-        });
+        create(Tables.AUCTION_ITEMS, StorageSchemaDefinitions::auctionItems);
     }
 }

--- a/src/main/java/fr/maxlego08/zauctionhouse/storage/migrations/CreateItemMigration.java
+++ b/src/main/java/fr/maxlego08/zauctionhouse/storage/migrations/CreateItemMigration.java
@@ -1,24 +1,13 @@
 package fr.maxlego08.zauctionhouse.storage.migrations;
 
 import fr.maxlego08.sarah.database.Migration;
-import fr.maxlego08.zauctionhouse.api.item.StorageType;
 import fr.maxlego08.zauctionhouse.api.storage.Tables;
+import fr.maxlego08.zauctionhouse.storage.StorageSchemaDefinitions;
 
 public class CreateItemMigration extends Migration {
 
     @Override
     public void up() {
-        create(Tables.ITEMS, table -> {
-            table.autoIncrement("id");
-            table.string("item_type", 255);
-            table.string("seller_unique_id", 36).foreignKey(Tables.PLAYERS, "unique_id", true);
-            table.string("buyer_unique_id", 36).nullable().foreignKey(Tables.PLAYERS, "unique_id", true);
-            table.decimal("price", 65, 2);
-            table.string("economy_name", 255);
-            table.enumType("storage_type", StorageType.class);
-            table.string("server_name", 255);
-            table.timestamp("expired_at");
-            table.timestamps();
-        });
+        create(Tables.ITEMS, StorageSchemaDefinitions::items);
     }
 }

--- a/src/main/java/fr/maxlego08/zauctionhouse/storage/migrations/CreateLogsMigration.java
+++ b/src/main/java/fr/maxlego08/zauctionhouse/storage/migrations/CreateLogsMigration.java
@@ -2,23 +2,12 @@ package fr.maxlego08.zauctionhouse.storage.migrations;
 
 import fr.maxlego08.sarah.database.Migration;
 import fr.maxlego08.zauctionhouse.api.storage.Tables;
+import fr.maxlego08.zauctionhouse.storage.StorageSchemaDefinitions;
 
 public class CreateLogsMigration extends Migration {
 
     @Override
     public void up() {
-        create(Tables.LOGS, table -> {
-            table.autoIncrement("id");
-            table.integer("item_id").foreignKey(Tables.ITEMS, "id", true);
-            table.string("log_type", 255);
-            table.string("player_unique_id", 36).foreignKey(Tables.PLAYERS, "unique_id", true);
-            table.string("target_unique_id", 36).nullable().foreignKey(Tables.PLAYERS, "unique_id", true);
-            table.longText("itemstack").nullable();
-            table.decimal("price", 65, 2).defaultValue(0);
-            table.string("economy_name", 255).nullable();
-            table.longText("additional_data").nullable();
-            table.timestamp("readed_at").nullable();
-            table.timestamps();
-        });
+        create(Tables.LOGS, StorageSchemaDefinitions::logs);
     }
 }

--- a/src/main/java/fr/maxlego08/zauctionhouse/storage/migrations/CreatePlayerMigration.java
+++ b/src/main/java/fr/maxlego08/zauctionhouse/storage/migrations/CreatePlayerMigration.java
@@ -1,16 +1,13 @@
 package fr.maxlego08.zauctionhouse.storage.migrations;
 
 import fr.maxlego08.sarah.database.Migration;
+import fr.maxlego08.zauctionhouse.storage.StorageSchemaDefinitions;
 import fr.maxlego08.zauctionhouse.api.storage.Tables;
 
 public class CreatePlayerMigration extends Migration {
 
     @Override
     public void up() {
-        create(Tables.PLAYERS, table -> {
-            table.uuid("unique_id").primary().unique();
-            table.string("name", 16);
-            table.timestamps();
-        });
+        create(Tables.PLAYERS, StorageSchemaDefinitions::players);
     }
 }

--- a/src/main/java/fr/maxlego08/zauctionhouse/storage/migrations/CreateTransactionsMigration.java
+++ b/src/main/java/fr/maxlego08/zauctionhouse/storage/migrations/CreateTransactionsMigration.java
@@ -2,21 +2,12 @@ package fr.maxlego08.zauctionhouse.storage.migrations;
 
 import fr.maxlego08.sarah.database.Migration;
 import fr.maxlego08.zauctionhouse.api.storage.Tables;
+import fr.maxlego08.zauctionhouse.storage.StorageSchemaDefinitions;
 
 public class CreateTransactionsMigration extends Migration {
 
     @Override
     public void up() {
-        create(Tables.TRANSACTIONS, table -> {
-            table.autoIncrement("id");
-            table.integer("item_id").foreignKey(Tables.ITEMS, "id", true);
-            table.string("player_unique_id", 36).foreignKey(Tables.PLAYERS, "unique_id", true);
-            table.string("economy_name", 255);
-            table.decimal("before", 65, 2);
-            table.decimal("after", 65, 2);
-            table.decimal("value", 65, 2);
-            table.string("status", 32);
-            table.timestamps();
-        });
+        create(Tables.TRANSACTIONS, StorageSchemaDefinitions::transactions);
     }
 }


### PR DESCRIPTION
This fixes a startup issue where SQLite installs could query zauctionhouse_players / zauctionhouse_transactions before those tables existed.

### What changed

- Make the migration tracking table follow the active configured table prefix instead of using a hard-coded name.

- Add a startup schema self-check that recreates required core tables when migration bookkeeping is stale or out of sync.

- Reuse shared schema definitions for both migrations and self-healing table creation so the structure stays consistent.

- Prefer the legacy storage.db SQLite file when it exists and database.db does not, to avoid silently pointing old installs at a fresh empty database.

### Why
Some installs were in a bad state where the configured prefix no longer matched previously recorded migration metadata, or the plugin was looking at a different SQLite file than the one containing the live data.

In those cases migrations could be treated as already applied while the actual prefixed tables were missing, causing runtime failures on player join and claim lookups.